### PR TITLE
Update jquery.bsAlerts.js

### DIFF
--- a/docs/js/jquery.bsAlerts.js
+++ b/docs/js/jquery.bsAlerts.js
@@ -124,7 +124,7 @@
         if (self.options.usebullets) {
           $ul.append($("<li/>").html(it.message));
         } else {
-          $ul.append(ix > 0 ? "<br /><br />" + it.message : it.message);
+          $ul.append(ix > 0 || $ul[0].childNodes.length ? "<br /><br />" + it.message : it.message);
         }
       });
     };


### PR DESCRIPTION
When using usebullets="false", include line breaks between items of the same priority - regardless of whether the add-alerts trigger calls are chained together or separate calls (mimicking the default functionality)