### PR TITLE
Update jquery.bsAlerts.js

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -33,6 +33,7 @@
         <li><a href="#usage">Usage</a></li>
         <li><a href="#options">Options</a></li>
         <li><a href="#events">Events</a></li>
+        <li><a href="#multiple-containers">Multiple Containers per Page Example</a></li>
       </ul>
     </div>
     <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
@@ -67,7 +68,7 @@ $("#warn-me").click(function() {
   $(document).trigger("add-alerts", [
     {
       "message": "This is a warning.",
-      "priority": 'warning'
+      "priority": "warning"
     }
   ]);
 });
@@ -173,6 +174,84 @@ $(document).trigger("set-alert-id-myid", {
 
         <div class="alert alert-info"><strong>Tip:</strong> Copy and paste the above commands into the JavaScript console to see them in action.</div>
       </section>
+    
+    <h2 class="sub-header"><a id="multiple-containers"></a>Multiple Containers per Page Example</h2>
+      <section id="multiple-containers">
+        <div id="generic-error-container" data-alerts="alerts" data-titles='{"warning": "<em>Warning!</em>", "error": "<em>Error!</em>"}' data-ids="myid"></div>
+        <br /><br /><br />
+        <button id="warn-me-first" class="btn trigger-bsalert">Click to see a warning alert in both containers</button>
+        <br /><br />
+        <button id="warn-me-more" class="btn trigger-bsalert">Click to add another warning alert in both containers</button>
+        <br /><br />
+        <button id="clear-me" class="btn trigger-bsalert">Clear all alerts</button>
+        <hr>
+        <div id="specific-error-container" data-alerts="alerts" data-titles='{"warning": "<em>Warning!</em>", "error": "<em>Error!</em>"}' data-ids="myid"></div>
+        <br /><br /><br />
+        <button id="warn-me-second" class="btn trigger-bsalert">Click to see a warning alert in just the second container</button>
+        <br /><br />
+        <button id="warn-me-again" class="btn trigger-bsalert">Click to add another warning alert in just the second container</button>
+        <br /><br />
+        <button id="clear-just-me" class="btn trigger-bsalert">Clear just second container alerts</button>
+        <hr />
+<pre class="prettyprint linenums">
+&lt;div id="generic-error-container" data-alerts="alerts" data-titles='{"warning": "&lt;em&gt;Warning!&lt;/em&gt;", "error": "&lt;em&gt;Error!&lt;/em&gt;"}' data-ids="myid"&gt;&lt;/div&gt;
+&lt;br /&gt;&lt;br /&gt;&lt;br /&gt;
+&lt;button id="warn-me" class="btn trigger-bsalert"&gt;Click to see a warning alert in both containers&lt;/button&gt;
+&lt;br /&gt;&lt;br /&gt;
+&lt;button id="warn-me-more" class="btn trigger-bsalert"&gt;Click to add another warning alert in both containers&lt;/button&gt;
+&lt;br /&gt;&lt;br /&gt;
+&lt;button id="clear-me" class="btn trigger-bsalert"&gt;Clear all alerts&lt;/button&gt;
+&lt;br /&gt;&lt;br /&gt;&lt;br /&gt;
+&lt;div id="specific-error-container" data-alerts="alerts" data-titles='{"warning": "&lt;em&gt;Warning!&lt;/em&gt;", "error": "&lt;em&gt;Error!&lt;/em&gt;"}' data-ids="myid"&gt;&lt;/div&gt;
+&lt;br /&gt;&lt;br /&gt;&lt;br /&gt;
+&lt;button id="warn-me-second" class="btn trigger-bsalert"&gt;Click to see a warning alert in just the second container&lt;/button&gt;
+&lt;br /&gt;&lt;br /&gt;
+&lt;button id="warn-me-again" class="btn trigger-bsalert"&gt;Click to add another warning alert in just the second container&lt;/button&gt;
+&lt;br /&gt;&lt;br /&gt;
+&lt;button id="clear-just-me" class="btn trigger-bsalert"&gt;Clear just second container alerts&lt;/button&gt;
+&lt;script&gt;
+$("#warn-me").click(function() {
+  $(document).trigger("clear-alerts");
+  $(document).trigger("add-alerts", {
+    message: "This is a warning.",
+    priority: "warning"
+  });
+});
+
+$("#warn-me-more").click(function() {
+  $(document).trigger("add-alerts", {
+    message: "This is a warning.",
+    priority: "warning"
+  });
+});
+
+$("#clear-me").click(function() {
+  $(document).trigger("clear-alerts");
+});
+
+$("#warn-me-second").click(function() {
+  $(document).trigger("clear-alerts", "specific-error-container");
+  $(document).trigger("add-alerts", {
+    message: "This is a specific warning.",
+    priority: "warning",
+    destination: "specific-error-container"
+  });
+});
+
+$("#warn-me-again").click(function() {
+  $(document).trigger("add-alerts", {
+    message: "This is a specific warning.",
+    priority: "warning",
+    destination: "specific-error-container"
+  });
+});
+
+$("#clear-just-me").click(function() {
+  $(document).trigger("clear-alerts", "specific-error-container");
+});
+&lt;/script&gt;
+</pre>
+      </section>
 
       <footer class="footer">
         <div class="container">
@@ -201,6 +280,46 @@ $(document).trigger("set-alert-id-myid", {
             "priority": 'warning'
           }
         ]);
+      });
+      
+      $("#warn-me").click(function() {
+        $(document).trigger("clear-alerts");
+        $(document).trigger("add-alerts", {
+          message: "This is a warning.",
+          priority: "warning"
+        });
+      });
+
+      $("#warn-me-more").click(function() {
+        $(document).trigger("add-alerts", {
+          message: "This is a warning.",
+          priority: "warning"
+        });
+      });
+
+      $("#clear-me").click(function() {
+        $(document).trigger("clear-alerts");
+      });
+
+      $("#warn-me-second").click(function() {
+        $(document).trigger("clear-alerts", "specific-error-container");
+        $(document).trigger("add-alerts", {
+          message: "This is a specific warning.",
+          priority: "warning",
+          destination: "specific-error-container"
+        });
+      });
+
+      $("#warn-me-again").click(function() {
+        $(document).trigger("add-alerts", {
+          message: "This is a specific warning.",
+          priority: "warning",
+          destination: "specific-error-container"
+        });
+      });
+
+      $("#clear-just-me").click(function() {
+        $(document).trigger("clear-alerts", "specific-error-container");
       });
 
       prettyPrint();

--- a/docs/js/jquery.bsAlerts.js
+++ b/docs/js/jquery.bsAlerts.js
@@ -18,7 +18,13 @@
     });
 
     $(document).on("clear-alerts", function() {
-      self.clearAlerts();
+      if (arguments && arguments[1] && arguments[1].length) {
+        // clearing only alerts for a specific element
+        self.clearAlerts(arguments[1]);
+      } else {
+        // clear all alerts
+        self.clearAlerts();
+      }
     });
 
     $.each(this.options.ids.split(","), function(ix, alert_id) {
@@ -40,8 +46,14 @@
       titles[bsPriority(key)] = title;
     });
 
-    self.clearAlerts = function() {
-      $(this.element).html("");
+    self.clearAlerts = function(destinationId) {
+      // clearing only alerts for a specific element
+      if (destinationId && destinationId.length) {
+        $("#" + destinationId).html("");      
+      } else {
+        // clear all alerts
+        $(this.element).html("");
+      }
     };
 
     self.addAlerts = function(data) {
@@ -105,27 +117,40 @@
     self.addAlertsToContainer = function(msgs) {
       if (msgs.length > 0) {
         var $ele = $(this.element);
-        var priority = bsPriority(msgs[0].priority);
-        var $container = $("[data-alerts-container=\""+priority+"\"]", $ele);
-
-        if ($container.length > 0) {
-          var $ul = self.options.usebullets ? $container.find("ul") : $container.find("p");
-          self.attachLIs($ul, msgs);
+        
+        // by default, display this message
+        var okToPush = true;
+        
+        // if a destination was specified, then only push the message to that specific container
+        if (msgs[0] && msgs[0].destination && msgs[0].destination !== $ele.attr("id")) {
+          okToPush = false;
         }
-        else {
-          $container = self.buildNoticeContainer(msgs);
-          $ele.append($container);
+        
+        // if this message is intended for this container, display it  
+        if (okToPush) {
+          var priority = bsPriority(msgs[0].priority);
+          var $container = $("[data-alerts-container=\""+priority+"\"]", $ele);
+  
+          if ($container.length > 0) {
+            var $ul = self.options.usebullets ? $container.find("ul") : $container.find("p");
+            self.attachLIs($ul, msgs);
+          }
+          else {
+            $container = self.buildNoticeContainer(msgs);
+            $ele.append($container);
+          }
         }
       }
     };
 
-    self.attachLIs = function($ul, msgs) {
+    self.attachLIs = function($ul, msgs, usebullets) {    	
       $.each(msgs, function(ix, it) {
         if (self.options.usebullets) {
-          $ul.append($("<li/>").html(it.message));
+        	$ul.append($("<li/>").html(it.message));
         } else {
-          $ul.append(ix > 0 || $ul[0].childNodes.length ? "<br /><br />" + it.message : it.message);
+        	$ul.append(ix > 0 || $ul[0].childNodes.length ? "<br /><br />" + it.message : it.message);
         }
+    	  
       });
     };
 
@@ -202,6 +227,7 @@
   $(document).ready(function () {
     $("[data-alerts=\"alerts\"]").each(function () {
       var $ele = $(this);
+      
       $ele.bsAlerts($ele.data());
     });
   });

--- a/docs/js/jquery.bsAlerts.js
+++ b/docs/js/jquery.bsAlerts.js
@@ -133,7 +133,7 @@
   
           if ($container.length > 0) {
             var $ul = self.options.usebullets ? $container.find("ul") : $container.find("p");
-            self.attachLIs($ul, msgs);
+            self.attachLIs($ul, msgs, self.options.usebullets);
           }
           else {
             $container = self.buildNoticeContainer(msgs);
@@ -145,7 +145,7 @@
 
     self.attachLIs = function($ul, msgs, usebullets) {    	
       $.each(msgs, function(ix, it) {
-        if (self.options.usebullets) {
+        if (usebullets) {
         	$ul.append($("<li/>").html(it.message));
         } else {
         	$ul.append(ix > 0 || $ul[0].childNodes.length ? "<br /><br />" + it.message : it.message);


### PR DESCRIPTION
Adding the ability to have multiple alert containers on the same page. These can either all receive all alerts, or the add and clear alert actions have been updated to optionally pass along a destination element id. If provided, then the add/clear action will only impact the specified element - while the default behavior of generically adding/clearing to any subscribed elements (which would typically be one) is preserved. 

For an example of both the default behavior and the new, see these plunkers: [http://embed.plnkr.co/Z4jK9y/](http://embed.plnkr.co/Z4jK9y/) - includes a custom wrapper I use, [http://embed.plnkr.co/89oSao/](http://embed.plnkr.co/89oSao/) - does not include this wrapper for clarity